### PR TITLE
Replace GitHub with Source Code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,7 +29,7 @@ URL = "https://docs.hedgedoc.org"
 weight = 2
 
 [[menu.main]]
-name = "GitHub"
+name = "Source Code"
 URL = "https://git.hedgedoc.org"
 weight = 3
 
@@ -50,7 +50,7 @@ weight = 6
 
 # footer menu
 [[menu.footer]]
-name = "GitHub"
+name = "Source Code"
 URL = "https://git.hedgedoc.org"
 weight = 1
 


### PR DESCRIPTION
This patch should avoid the usage of brand terminology for general concepts. ("Kleenex"/"Tempo" vs tissue)