### PR TITLE
Add google site verification to head

### DIFF
--- a/themes/vex-hugo/layouts/partials/head.html
+++ b/themes/vex-hugo/layouts/partials/head.html
@@ -31,6 +31,7 @@
   <meta name="msapplication-config" content="{{ `icons/browserconfig.xml`| absURL }}">
   <meta name="theme-color" content="#b51f08">
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <meta name="google-site-verification" content="gQ36MdAbZV2llqfbMwYTeOgo4rnL0dSejC_eolu89uw" />
   <meta property="og:image" content="{{ `icons/apple-touch-icon.png`| absURL }}" />
   {{ template "_internal/opengraph.html" . }}
 


### PR DESCRIPTION
This PR adds adds a google site verification token, so we can access the google webmaster tools and see how google indexes  the page. This does NOT add any kind of tracking, google analytics or other metrics. This won't change anything for the users. This is only to control how the google crawler interacts with our page.