### PR TITLE
Added mastodon verification link

### DIFF
--- a/themes/vex-hugo/layouts/partials/head.html
+++ b/themes/vex-hugo/layouts/partials/head.html
@@ -37,9 +37,12 @@
     <meta name="msapplication-config" content="{{ `icons/browserconfig.xml`| absURL }}">
     <meta name="theme-color" content="#b51f08">
     <meta content="width=device-width, initial-scale=1" name="viewport"/>
-    <meta name="google-site-verification" content="gQ36MdAbZV2llqfbMwYTeOgo4rnL0dSejC_eolu89uw"/>
     <meta property="og:image" content="{{ `icons/apple-touch-icon.png`| absURL }}"/>
     {{ template "_internal/opengraph.html" . }}
+
+    <!-- verifications -->
+    <link rel="me" href="https://social.snopyta.org/@hedgedoc">
+    <meta name="google-site-verification" content="gQ36MdAbZV2llqfbMwYTeOgo4rnL0dSejC_eolu89uw"/>
 
     <script src="{{ `js/mobile-menu.js` | absURL }}" defer></script>
 </head>


### PR DESCRIPTION
This PR added the mastodon me-link for verification of our homepage link on the profile. The google-webmasters-verification id is also moved into a new verifications section in the head.

Closes #22 