### PR TITLE
Fix min height of history split elements

### DIFF
--- a/themes/vex-hugo/assets/scss/history.scss
+++ b/themes/vex-hugo/assets/scss/history.scss
@@ -23,18 +23,18 @@
   }
 
 
-.split-from-right, .split-start  {
-&:after {
-    content: ' ';
-    padding-bottom: 50%;
-    position: relative;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 100%;
-    display: block;
-}
-}
+  .split-from-right, .split-start {
+    &:after {
+      content: ' ';
+      padding-bottom: 50%;
+      position: relative;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 100%;
+      display: block;
+    }
+  }
 
   .single {
     background-image: url(/history/single.svg);

--- a/themes/vex-hugo/assets/scss/history.scss
+++ b/themes/vex-hugo/assets/scss/history.scss
@@ -22,6 +22,20 @@
     }
   }
 
+
+.split-from-right, .split-start  {
+&:after {
+    content: ' ';
+    padding-bottom: 50%;
+    position: relative;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    display: block;
+}
+}
+
   .single {
     background-image: url(/history/single.svg);
   }


### PR DESCRIPTION
### Description
On some display resolutions the history graphs seems to be broken. This PR adds a css fix for this.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
