### PR TITLE
Change november to december

### DIFF
--- a/content/english/history.html
+++ b/content/english/history.html
@@ -84,7 +84,12 @@ title: History
 
 {{< history-entry graph="straight-left point-left red">}}
     <h3><time>November '20</time></h3>
-    The community releases HedgeDoc 1.7 with the new name and the new logo.
+    The community publishes release candidates for HedgeDoc 1.7 with the new name and the new logo.
+{{< /history-entry >}}
+
+{{< history-entry graph="straight-left point-left red">}}
+    <h3><time>December '20</time></h3>
+    HedgeDoc 1.7 is released
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}

--- a/content/english/history.html
+++ b/content/english/history.html
@@ -83,13 +83,8 @@ title: History
 {{< /history-entry >}}
 
 {{< history-entry graph="straight-left point-left red">}}
-    <h3><time>November '20</time></h3>
-    The community publishes release candidates for HedgeDoc 1.7 with the new name and the new logo.
-{{< /history-entry >}}
-
-{{< history-entry graph="straight-left point-left red">}}
     <h3><time>December '20</time></h3>
-    HedgeDoc 1.7 is released
+    The community publishes HedgeDoc 1.7 with the new name and the new logo.
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}


### PR DESCRIPTION
### Description
This PR changes the history entry for november and adds a history entry for december. November is changed to "release candidate" and december is about the release.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
