### PR TITLE
Explain `X-Frame-Options` for PDF embedding

### DIFF
--- a/content/english/faq.md
+++ b/content/english/faq.md
@@ -59,3 +59,16 @@ Starting with HedgeDoc 2.0, mermaid is used for rendering sequence-diagrams. The
     John-->>Alice: Great!
     ```
 {{< /faq-entry >}}
+
+{{< faq-entry title="Why can't I embed some PDFs?" >}}  
+Many servers don't allow the embedding of their content on arbitrary sites.
+
+For a more technical explanation:  
+The `X-Frame-Options` header can be used to specify if a given webpage can be embedded.
+For security reasons this header is often set to `SAMEORIGIN`, which disallows embedding on other origins.
+To be able to embed a PDF inside a HedgeDoc note, the server that hosts the PDF must either send no `X-Frame-Options`
+header (which might be insecure) or include the URI of your HedgeDoc instance in an `ALLOW-FROM` statement.
+See [Mozillas docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) for more details.
+Also note that the `X-Frame-Options` header [is being obsoleted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
+by the `frame-ancestors` statement in the `Content-Security-Policy` header.
+{{< /faq-entry >}}


### PR DESCRIPTION
### Description
This PR adds an explanation about the `X-Frame-Options` header and how it relates to PDF embedding.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
