### PR TITLE
Add button for manual deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ name: Deploy to github actions branch
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
### Description
This PR adds a new trigger to the `deploy` action so it can be triggered manually.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
