### PR TITLE
Remove unnecessary trigger

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -4,7 +4,7 @@
 
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   reuse:


### PR DESCRIPTION
### Description
The "Pull Request" trigger in reuse.yml is unnecessary. The check is already covered by "push"

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

