### PR TITLE
Replace getting started link with a working one

### DIFF
--- a/data/en/homepage.yml
+++ b/data/en/homepage.yml
@@ -17,7 +17,7 @@ banner:
   buttons:
   - enable : true
     label : "Getting started"
-    link : "https://docs.hedgedoc.org/tutorial/getting-started"
+    link : "https://github.com/hedgedoc/hedgedoc/#installation--upgrading"
   - enable: true
     label: "Visit the demo"
     link: "https://demo.hedgedoc.org/"


### PR DESCRIPTION
### Description
This PR replaces the "getting started" link with a useful one until our docs page is ready.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

