### PR TITLE
Added docker tags to release page

### DIFF
--- a/assets/scss/additional-theme.scss
+++ b/assets/scss/additional-theme.scss
@@ -52,9 +52,12 @@ a:focus,
   }
 }
 
-.content {
+.docker-command {
   pre {
     padding: 10px 20px;
-    background: #dadada;
+    background: #f7f7f9;
+  }
+  code:before {
+    content: "> "
   }
 }

--- a/github-releases.ts
+++ b/github-releases.ts
@@ -65,6 +65,7 @@ export const githubReleases = async () => {
               Title: entry.name,
               date: entry.created_at,
               tarball: entry.tarball_url,
+              legacyRelease: entry.name.includes('CodiMD'),
               docker: dockerTag
                 ? {
                   tag: dockerTag.name,

--- a/github-releases.ts
+++ b/github-releases.ts
@@ -5,8 +5,8 @@
 */
 
 import fetch from 'node-fetch';
-import yaml from "yaml";
-import fs from "fs/promises";
+import yaml from 'yaml';
+import fs from 'fs/promises';
 
 interface GitHubReleaseEntry {
   id: string
@@ -25,42 +25,84 @@ interface GitHubReleaseEntry {
   draft: boolean
 }
 
+interface QuayResponse {
+  has_additional: boolean
+  page: number
+  tags: QuayImageTagEntry[]
+}
+
+interface QuayImageTagEntry {
+  name: string
+  reversion: boolean
+  end_ts: number
+  start_ts: number
+  image_id: string
+  last_modified: string
+  expiration: string
+  manifest_digest: string
+  docker_image_id: string
+  is_manifest_list: boolean
+  size: number
+}
+
 export const githubReleases = async () => {
-  fetch('https://api.github.com/repos/hedgedoc/hedgedoc/releases')
-    .catch(err => {
-      console.log("Can't connect to GitHub API ", err);
-      process.exit();
-    })
+  fetch('https://quay.io/api/v1/repository/hedgedoc/hedgedoc/tag/')
     .then(res => res.json())
-    .then((json: GitHubReleaseEntry[]) => {
-      json = json.filter((entry: GitHubReleaseEntry) => !entry.prerelease && !entry.draft)
+    .then((quayJson: QuayResponse) => {
+      const dockerTags = new Map<string, QuayImageTagEntry>()
+      quayJson.tags.forEach(tagEntry => {
+        dockerTags.set(tagEntry.name, tagEntry)
+      })
+      fetch('https://api.github.com/repos/hedgedoc/hedgedoc/releases')
+        .then(res => res.json())
+        .then((githubJson: GitHubReleaseEntry[]) => {
+          githubJson = githubJson.filter((entry: GitHubReleaseEntry) => !entry.prerelease && !entry.draft)
 
-      json.forEach(entry => {
-        const frontmatterJson = {
-          Title: entry.name,
-          date: entry.created_at,
-          tarball: entry.tarball_url,
-          assets: entry.assets.map(asset => {
-            return {
-              name: asset.name,
-              url: asset.browser_download_url,
-              size: asset.size
-            }
-          }),
-          githubLink: entry.html_url
-        };
+          githubJson.forEach(entry => {
+            const dockerTag = dockerTags.get(entry.tag_name)
 
-        const content = `---
+            const frontmatterJson = {
+              Title: entry.name,
+              date: entry.created_at,
+              tarball: entry.tarball_url,
+              docker: dockerTag
+                ? {
+                  tag: dockerTag.name,
+                  size: dockerTag.size,
+                  alpine: dockerTags.has(`${entry.tag_name}-alpine`)
+                }
+                : undefined
+              ,
+              assets: entry.assets.map(asset => {
+                return {
+                  name: asset.name,
+                  url: asset.browser_download_url,
+                  size: asset.size
+                }
+              }),
+              githubLink: entry.html_url
+            };
+
+            const content = `---
 ${yaml.stringify(frontmatterJson)}
 ---
 ${entry.body}`;
 
-        const filename = `content/english/releases/${entry.tag_name}.md`;
+            const filename = `content/english/releases/${entry.tag_name}.md`;
 
-        fs.access(filename).catch(() => {
-          console.log("write file ", filename);
-          fs.writeFile(filename, content);
+            fs.access(filename).catch(() => {
+              console.log('write file ', filename);
+              fs.writeFile(filename, content);
+            });
+          });
+        })
+        .catch(err => {
+          console.error("Can't connect to GitHub API: ", err);
+          process.exit(1);
         });
-      });
-    });
+    })
+    .catch(err => {
+      console.error('Quay.io image list retrieval failed: ', err)
+      process.exit(1)
+    })
 };

--- a/github-releases.ts
+++ b/github-releases.ts
@@ -69,7 +69,7 @@ export const githubReleases = async () => {
                 ? {
                   tag: dockerTag.name,
                   size: dockerTag.size,
-                  alpine: dockerTags.has(`${entry.tag_name}-alpine`)
+                  alpineImageAvailable: dockerTags.has(`${entry.tag_name}-alpine`)
                 }
                 : undefined
               ,

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -91,21 +91,21 @@
                     <div class="row">
                         <h3 class="mb-3">Docker</h3>
                     </div>
-                    <p>
-                        Our docker images are located on quay.io at <a href="https://quay.io/repository/hedgedoc/hedgedoc">hedgedoc/hedgedoc</a>.
-                    </p>
                     {{ if eq .Page.Params.docker nil }}
                     <p>
                         {{ if eq .Page.Params.legacyRelease true }}
                         This version was released before the rebranding to HedgeDoc. Docker images can be found in the old repository:
                         <a href="https://quay.io/repository/codimd/server?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io/codimd/server</a>
                         {{ else }}
-                        This version hasn't been released as docker image yet. Come back soon or check out our docker repository at <a href="https://quay.io/repository/hedgedoc/hedgedoc?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io hedgedoc/hedgedoc</a>
+                        This version hasn't been released as docker image yet. Come back later or check out our docker repository at <a href="https://quay.io/repository/hedgedoc/hedgedoc?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io hedgedoc/hedgedoc</a>
                         {{ end }}
                     </p>
                     {{ end }}
 
                     {{ if ne .Page.Params.docker nil }}
+                    <p>
+                        Our docker images are located on quay.io at <a href="https://quay.io/repository/hedgedoc/hedgedoc">hedgedoc/hedgedoc</a>.
+                    </p>
                     <h4>Debian-based image</h4>
                     <p>
                         You can pull our docker image directly with the command below. It is based on Debian Linux ({{ printf "%.2f" (div .Page.Params.docker.size 1000000.0) }} MB).

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -109,7 +109,7 @@
                     <div class="row docker-command">
                         <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ .Page.Params.docker.tag }}</code></pre>
                     </div>
-                    {{ if eq .Page.Params.docker.alpine true }}
+                    {{ if eq .Page.Params.docker.alpineImageAvailable true }}
                     <br>
                     <h4>Alpine-based image</h4>
                     <p>

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -96,8 +96,12 @@
                     </p>
                     {{ if eq .Page.Params.docker nil }}
                     <p>
+                        {{ if eq .Page.Params.legacyRelease true }}
                         This version was released before the rebranding to HedgeDoc. Docker images can be found in the old repository:
                         <a href="https://quay.io/repository/codimd/server?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io/codimd/server</a>
+                        {{ else }}
+                        This version hasn't been released as docker image yet. Come back soon or check out our docker repository at <a href="https://quay.io/repository/hedgedoc/hedgedoc?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io hedgedoc/hedgedoc</a>
+                        {{ end }}
                     </p>
                     {{ end }}
 

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -102,7 +102,7 @@
                     {{ end }}
 
                     {{ if ne .Page.Params.docker nil }}
-                    <h4>Docker-based image</h4>
+                    <h4>Debian-based image</h4>
                     <p>
                         You can pull our docker image directly with the command below. It is based on Debian Linux ({{ printf "%.2f" (div .Page.Params.docker.size 1000000.0) }} MB).
                     </p>

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -68,7 +68,7 @@
                         {{ range .Page.Params.assets }}
                         <a href="{{.url}}" target="_blank" rel="noopener noreferer" class="btn btn-success"><i
                                 class="fa fa-download"></i>&nbsp;{{ .name }}&nbsp;
-                            ({{ printf "%.2f" (div .size 1000000.0) }}MB)
+                            ({{ printf "%.2f" (div .size 1000000.0) }} MB)
                         </a>
                         {{ end }}
                     </div>
@@ -86,19 +86,42 @@
                     </div>
                 </div>
             </li>
-
-            {{ if isset .Params "docker-tag" }}
             <li class="list-group-item p-3">
                 <div class="col">
                     <div class="row">
                         <h3 class="mb-3">Docker</h3>
                     </div>
+                    <p>
+                        Our docker images are located on quay.io at <a href="https://quay.io/repository/hedgedoc/hedgedoc">hedgedoc/hedgedoc</a>.
+                    </p>
+                    {{ if eq .Page.Params.docker nil }}
+                    <p>
+                        This version was released before the rebranding to HedgeDoc. Docker images can be found in the old repository:
+                        <a href="https://quay.io/repository/codimd/server?tab=tags" target="_blank" rel="noreferrer nofollow">quay.io/codimd/server</a>
+                    </p>
+                    {{ end }}
+
+                    {{ if ne .Page.Params.docker nil }}
+                    <h4>Docker-based image</h4>
+                    <p>
+                        You can pull our docker image directly with the command below. It is based on Debian Linux ({{ printf "%.2f" (div .Page.Params.docker.size 1000000.0) }} MB).
+                    </p>
                     <div class="row docker-command">
-                        <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ index .Params "docker-tag" }}</code></pre>
+                        <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ .Page.Params.docker.tag }}</code></pre>
                     </div>
+                    {{ if eq .Page.Params.docker.alpine true }}
+                    <br>
+                    <h4>Alpine-based image</h4>
+                    <p>
+                        The alpine-based image is much smaller than the debian-based image, but does not contain <i>glibc</i> resulting in some debugging software not working properly in the container.
+                    </p>
+                    <div class="row docker-command">
+                        <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ .Page.Params.docker.tag }}-alpine</code></pre>
+                    </div>
+                    {{ end }}
+                    {{ end }}
                 </div>
             </li>
-            {{ end }}
         </ul>
     </div>
 </section>

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -87,20 +87,18 @@
                 </div>
             </li>
 
+            {{ if isset .Params "docker-tag" }}
             <li class="list-group-item p-3">
                 <div class="col">
                     <div class="row">
                         <h3 class="mb-3">Docker</h3>
                     </div>
-                    <div class="row">
-                        <p>
-                            Check out our docker repository on&nbsp;<a
-                                href="https://quay.io/repository/hedgedoc/hedgedoc?tab=tags" target="_blank"
-                                rel="noopener noreferer">quay.io</a>
-                        </p>
+                    <div class="row docker-command">
+                        <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ index .Params "docker-tag" }}</code></pre>
                     </div>
                 </div>
             </li>
+            {{ end }}
         </ul>
     </div>
 </section>


### PR DESCRIPTION
### Description
This PR adds the docker tags matching each version to their release page.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #56 
