### PR TITLE
Fix setup index link

### DIFF
--- a/content/english/_index.html
+++ b/content/english/_index.html
@@ -8,7 +8,7 @@ HedgeDoc (formerly known as CodiMD) is an open-source collaborative markdown edi
 With HedgeDoc you can easily collaborate on notes, graphs and even presentations in real-time.
 All you need to do is to share your note-link to your co-workers, and they're ready to go.
 
-{{< button external=true label="Getting started" link="https://github.com/hedgedoc/hedgedoc/#installation--upgrading" >}}
+{{< button external=true label="Getting started" link="https://docs.hedgedoc.org/setup/" >}}
 {{< button external=true label="Visit the demo" link="https://demo.hedgedoc.org/" outline=true >}}
 {{< /banner >}}
 
@@ -19,7 +19,7 @@ All you need to do is to share your note-link to your co-workers, and they're re
 {{< icon-promo title="Let's get it started!" icon="rocket" background="secondary" right=true >}}
 Installing HedgeDoc is easy! We provide a ready to use bundle and a docker image. For details, take a look at our install guides.
 
-{{< button external=true label="Read the install guides" link="https://github.com/hedgedoc/hedgedoc/#installation--upgrading" >}}
+{{< button external=true label="Read the install guides" link="https://docs.hedgedoc.org/setup/" >}}
 {{< /icon-promo >}}
 
 


### PR DESCRIPTION
### Description
This PR changes the link to the setup documentation. 
https://github.com/hedgedoc/hedgedoc/pull/741 is needed for this.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
