### PR TITLE
Replace URL of "getting started" Link on the main page

### DIFF
--- a/content/english/_index.html
+++ b/content/english/_index.html
@@ -8,7 +8,7 @@ HedgeDoc (formerly known as CodiMD) is an open-source collaborative markdown edi
 With HedgeDoc you can easily collaborate on notes, graphs and even presentations in real-time.
 All you need to do is to share your note-link to your co-workers, and they're ready to go.
 
-{{< button external=true label="Getting started" link="https://docs.hedgedoc.org/setup/" >}}
+{{< button external=true label="Getting started" link="https://docs.hedgedoc.org/setup/getting-started" >}}
 {{< button external=true label="Visit the demo" link="https://demo.hedgedoc.org/" outline=true >}}
 {{< /banner >}}
 


### PR DESCRIPTION
### Description
This PR fixes the "Getting Started" Link on the main page.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

