### PR TITLE
Replace URL of "getting started" Link on the main page

### DIFF
--- a/content/english/_index.html
+++ b/content/english/_index.html
@@ -19,7 +19,7 @@ All you need to do is to share your note-link to your co-workers, and they're re
 {{< icon-promo title="Let's get it started!" icon="rocket" background="secondary" right=true >}}
 Installing HedgeDoc is easy! We provide a ready to use bundle and a docker image. For details, take a look at our install guides.
 
-{{< button external=true label="Read the install guides" link="https://docs.hedgedoc.org/setup/" >}}
+{{< button external=true label="Read the install guides" link="https://docs.hedgedoc.org/setup/getting-started" >}}
 {{< /icon-promo >}}
 
 


### PR DESCRIPTION
### Description
This PR amends a broken-link

### Steps
 * [x]  Added changes
 * [x]  I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.