### PR TITLE
Add CI checker for broken links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Check links
 
 on: 
@@ -10,10 +14,37 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for broken links
     steps:
-    - name: Check for broken links
-      id: link-report
-      uses: celinekurpershoek/link-checker@v1.0.1
-      with:
-        url: 'https://hedgedoc.org/'
-    - name: Get link check results
-      run: echo "${{steps.link-report.outputs.result}}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline && yarn add broken-link-checker
+
+      - name: Run Hugo
+        run: hugo server -e production --minify -b http://localhost:1313/ & sleep 5
+ 
+      - name: Check for broken links
+        run: node_modules/.bin/blc http://localhost:1313/ -ro

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,4 +47,5 @@ jobs:
         run: hugo server -e production --minify -b http://localhost:1313/ & sleep 5
  
       - name: Check for broken links
-        run: node_modules/.bin/blc http://localhost:1313/ -ro
+        # GitHub is excluded because we otherwise run into rate-limits and get many HTTP_429 link errors.
+        run: node_modules/.bin/blc http://localhost:1313/ -ro --exclude "https://github.com/*"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,19 @@
+name: Check links
+
+on: 
+  push:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    name: Check for broken links
+    steps:
+    - name: Check for broken links
+      id: link-report
+      uses: celinekurpershoek/link-checker@v1.0.1
+      with:
+        url: 'https://hedgedoc.org/'
+    - name: Get link check results
+      run: echo "${{steps.link-report.outputs.result}}"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,4 +48,5 @@ jobs:
  
       - name: Check for broken links
         # GitHub is excluded because we otherwise run into rate-limits and get many HTTP_429 link errors.
-        run: node_modules/.bin/blc http://localhost:1313/ -ro --exclude "https://github.com/*"
+        # Twitter (via our redirector) is excluded because they seem to block such checks, resulting in HTTP_400 errors.
+        run: node_modules/.bin/blc http://localhost:1313/ -ro --exclude "https://github.com/*" --exclude "https://social.hedgedoc.org/twitter"


### PR DESCRIPTION
### Description
This PR adds a GitHub CI job checking for broken links. It is based on the [broken-link-checker npm package](https://www.npmjs.com/package/broken-link-checker). The check runs on pushes to the repo as well as daily scheduled.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Avoiding further unnoticed broken links as reported with #77 
