### PR TITLE
Fix grammar of re-license in history.

### DIFF
--- a/content/english/history.html
+++ b/content/english/history.html
@@ -40,7 +40,7 @@ title: History
 
 {{< history-entry graph="double point-left">}}
     <h3><time>June '18</time></h3>
-    The HackMD EE team proposes to replace the community-code of CodiMD with their rewrite of HackMD EE by <a rel="noopener noreferer" target="_blank" href="https://github.com/hackmdio/hackmd/issues/1170">switching to an open-core model. To use the core in their private fork, they want to re-licensing the new open source code under Apache 2.0.</a>
+    The HackMD EE team proposes to replace the community-code of CodiMD with their rewrite of HackMD EE by <a rel="noopener noreferer" target="_blank" href="https://github.com/hackmdio/hackmd/issues/1170">switching to an open-core model. To use the core in their private fork, they want to re-license the new open source code under Apache 2.0.</a>
 {{< /history-entry >}}
 
 {{< history-entry graph="double point-right">}}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)

SPDX-License-Identifier: CC-BY-SA-4.0
-->

### Description
This PR fixes the grammar of "re-license" on the history page.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
