### PR TITLE
Change renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
     "config:base",
     ":gitSignOff",
     ":maintainLockFilesWeekly"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": [
+        "pin"
+      ]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":gitSignOff"
+    ":gitSignOff",
+    ":maintainLockFilesWeekly"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
         "pin"
       ]
     }
-  ]
+  ],
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
### Description
This PR changes the renovate config. It...
- Activates the weekly yarn.lock maintenance
- Removes the hourly PR limit
- Activate version pinning.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
