### PR TITLE
Set renovate schedule to hourly and activate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,8 @@
     ":gitSignOff",
     ":maintainLockFilesWeekly"
   ],
-  "packageRules": [
-    {
-      "updateTypes": [
-        "pin"
-      ]
-    }
-  ],
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
+  "schedule": [
+    "every 1 hour"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     ":gitSignOff",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    ":dependencyDashboard"
   ],
   "prHourlyLimit": 0,
   "schedule": [


### PR DESCRIPTION
### Description
This PR sets the renovate schedule to hourly and activates the dependency dashboard.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
