### PR TITLE
Fix typo in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,6 @@
   ],
   "prHourlyLimit": 0,
   "schedule": [
-    "every 1 hour"
+    "every 1 hours"
   ]
 }


### PR DESCRIPTION
### Description
This PR fixes a typo in the renovate config.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #67
