### PR TITLE
Change the release date for HedgeDoc 2.0 to "hopefully 2021"

### DIFF
--- a/content/english/history.html
+++ b/content/english/history.html
@@ -88,8 +88,8 @@ title: History
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}
-    <h3><time>Coming 2021</time></h3>
-    The community will release HedgeDoc 2.0.
+    <h3><time>2021</time></h3>
+    Tentative release date of HedgeDoc 2
 {{< /history-entry >}}
 
 </article>


### PR DESCRIPTION
### Description
This PR changes the predicted release date for HedgeDoc 2 to "hopefully 2021" instead of "2021".
We don't know if we can make it this year. Therefore I think we should communicate it like this on the website.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
