### PR TITLE
Rollback to hugo 0.83.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.83.1'
           extended: true
 
       - name: Use Node.js 14


### PR DESCRIPTION
### Description
This PR pins hugo to 0.83.1.
Hugo 0.84.0 has a bug where menus with custom entries won't get rendered. See https://github.com/gohugoio/hugo/issues/8672

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
