### PR TITLE
Change single quotes to double quotes in hugo version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           # renovate: datasource=github-releases depName=gohugoio/hugo versioning=semver
-          hugo-version: '0.83.1'
+          hugo-version: "0.83.1"
           extended: true
 
       - name: Use Node.js 14


### PR DESCRIPTION
### Description
Renovate config

### Steps
Replaces the single quotes in the hugo version in the deploy job with double quotes.

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
