### PR TITLE
Change release date of hedgedoc 2 to 2022

### DIFF
--- a/content/english/history.html
+++ b/content/english/history.html
@@ -88,7 +88,7 @@ title: History
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}
-    <h3><time>2021</time></h3>
+    <h3><time>2022</time></h3>
     Tentative release date of HedgeDoc 2
 {{< /history-entry >}}
 


### PR DESCRIPTION
### Description
This PR changes the release date of hedgedoc 2 to 2022. 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
