### PR TITLE
Add netlify to privacy policy

### DIFF
--- a/content/english/privacy-policy.md
+++ b/content/english/privacy-policy.md
@@ -13,6 +13,7 @@ There are some third party places where the HedgeDoc Project stores data:
 - [GitHub Pages][github-pages] is the website host. [Please refer to GitHub’s privacy practices document for details][github-privacy].
 - Our Chat is located on [matrix.org][matrix-org] at [#hedgedoc:matrix.org][chat]. [Refer to matrix.org's privacy policy for details][matrix-privacy].
 - The [demo instance][demo] stores login information (email addresses, password, GitHub Access Tokens, Twitter Access Tokens) and note information (content, revision and so on). [For details refer to the privacy notice of the demo instance][demo-privacy].
+- The [HedgeDoc 2 Frontend UI Test][frontend-test] is hosted by [Netlify][netlify]. [Please refer to Netlify's privacy policy for details][netlify-privacy].
 - We thankfully use [POEditor][translate] for all our translations. [Refer to POEditor’s privacy practices document for details][github-privacy].
 - The HedgeDoc code is stored in git, on [GitHub][github]. The git software does collect names and email addresses in repositories. GitHub has account information. [Refer to GitHub’s privacy policy for details][translate-privacy].
 
@@ -30,3 +31,7 @@ There are some third party places where the HedgeDoc Project stores data:
 
 [translate]: https://translate.hedgedoc.org
 [translate-privacy]: https://poeditor.com/terms/privacy
+
+[frontend-test]: https://hedgedoc.dev
+[netlify]: https://netlify.com
+[netlify-privacy]: https://www.netlify.com/privacy


### PR DESCRIPTION
### Description
This PR adds netlify to the privacy policy because the frontend demo is hosted there.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
