### PR TITLE
chore: add hugo server run config for WebStorm

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -22,3 +22,7 @@ License: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 Files: static/images/banner/*
 Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
 License: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
+
+Files: .run/*
+Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+License: CC-BY-SA-4.0

--- a/.run/start.run.xml
+++ b/.run/start.run.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="start" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="start" />
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@lhci/cli": "0.9.0"
   },
   "scripts": {
-    "prepare": "gulp"
+    "prepare": "gulp",
+    "start": "hugo server"
   }
 }


### PR DESCRIPTION
### Description
This PR adds a hugo server run config for WebStorm.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
