### PR TITLE
chore: added .hugo_build.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ static/fonts
 node_modules
 yarn-error.log
 content/english/releases/*.md
+.hugo_build.lock


### PR DESCRIPTION
### Description
This PR adds `.hugo_build.lock` to .gitignore

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
