### PR TITLE
Fix layout of history page

### DIFF
--- a/layouts/history/list.html
+++ b/layouts/history/list.html
@@ -1,1 +1,16 @@
-{{- block "main" . }}{{- end }}
+{{ define "main" }}
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <h1 class="mb-4">{{.Title | markdownify}}</h1>
+        <main>
+          {{.Content}}
+        </main>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{ end }}


### PR DESCRIPTION
### Description
This PR fixes the layout of `/history`

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
