### PR TITLE
fix: Outdated link to Mastodon account

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -49,7 +49,7 @@
     {{ template "_internal/opengraph.html" . }}
 
     <!-- verifications -->
-    <link rel="me" href="https://social.snopyta.org/@hedgedoc">
+    <link rel="me" href="https://fosstodon.org/@hedgedoc">
     <meta name="google-site-verification" content="gQ36MdAbZV2llqfbMwYTeOgo4rnL0dSejC_eolu89uw"/>
 
     <script src="{{ `js/mobile-menu.js` | absURL }}" defer></script>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)

SPDX-License-Identifier: CC-BY-SA-4.0
-->

### Description
This patch updates the link to the new mastodon account, and thereby providing the correct verification link.

### Steps
- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
