### PR TITLE
fix(releases): remove size

### DIFF
--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -78,7 +78,7 @@
                     <div class="row">
                         <div class="col">
                             {{ range .Page.Params.assets }}
-                            <a href="{{.url}}" class="btn btn-success"><i class="fa fa-download"></i>&nbsp;{{ .name }}&nbsp;({{ printf "%.2f" (div .size 1000000.0) }} MB)
+                            <a href="{{.url}}" class="btn btn-success"><i class="fa fa-download"></i>&nbsp;{{ .name }}
                             </a>
                             {{ end }}
                         </div>
@@ -122,7 +122,7 @@
                     </p>
                     <h4>Debian-based image</h4>
                     <p>
-                        You can pull our docker image directly with the command below. It is based on Debian Linux ({{ printf "%.2f" (div .Page.Params.docker.size 1000000.0) }} MB).
+                        You can pull our docker image directly with the command below. It is based on Debian Linux.
                     </p>
                     <div class="row docker-command">
                         <pre><code>docker pull quay.io/hedgedoc/hedgedoc:{{ .Page.Params.docker.tag }}</code></pre>


### PR DESCRIPTION
### Description
This PR removes the sizes of the docker images.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
