### PR TITLE
fix: change release date of hedgedoc 2

### DIFF
--- a/content/english/history/_index.html
+++ b/content/english/history/_index.html
@@ -92,7 +92,7 @@ title: History
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}
-    <h3><time>2022</time></h3>
+    <h3><time>2023</time></h3>
     Tentative release date of HedgeDoc 2
 {{< /history-entry >}}
 


### PR DESCRIPTION
### Description
This PR changes the release date of HedgeDoc 2 because we haven't released it in 2022.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
