### PR TITLE
fix: ts-node-esm not running the github-releases util

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node-fetch": "2.6.9"
   },
   "scripts": {
-    "prepare": "bash utils/copy-fonts.sh && ts-node-esm utils/github-releases.ts",
+    "prepare": "bash utils/copy-fonts.sh && node --experimental-specifier-resolution=node --loader ts-node/esm utils/github-releases.ts",
     "start": "hugo server"
   }
 }


### PR DESCRIPTION
### Description
This PR fixes the `yarn install` run by calling `node` directly with the `ts-node/esm` loader instead of using the `ts-node-esm` binary which is not compatible with current node anymore.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
