### PR TITLE
Adjust tentative release of v2 to 2024

### DIFF
--- a/content/english/history/_index.html
+++ b/content/english/history/_index.html
@@ -92,7 +92,7 @@ title: History
 {{< /history-entry >}}
 
 {{< history-entry graph="void-left point-left red">}}
-    <h3><time>2023</time></h3>
+    <h3><time>2024</time></h3>
     Tentative release date of HedgeDoc 2
 {{< /history-entry >}}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)

SPDX-License-Identifier: CC-BY-SA-4.0
-->

### Description

This PR adjusts the tentative release of v2 from 2023 to 2024

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I ~~read the [contribution documentation](https://github.com/hedgedoc/hedgedoc.github.io/blob/main/CONTRIBUTING.md) and~~ signed-off my commits to accept the DCO.

